### PR TITLE
Tasks 2–5: Kafka ingestion, H2/JPA persistence, Incentive API integration, and /balance endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,66 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
+
 	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<!-- Spring Boot Data JPA -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<version>3.2.5</version>
+		</dependency>
+
+		<!-- Spring Boot Web -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>3.2.5</version>
+		</dependency>
+
+		<!-- Spring Kafka -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+			<version>3.1.4</version>
+		</dependency>
+
+		<!-- H2 Database -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.2.224</version>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Spring Boot Test -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<version>3.2.5</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Spring Kafka Test -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<version>3.1.4</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Testcontainers Kafka -->
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>kafka</artifactId>
+			<version>1.19.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jpmc/midascore/component/TransactionListener.java
+++ b/src/main/java/com/jpmc/midascore/component/TransactionListener.java
@@ -1,0 +1,29 @@
+package com.jpmc.midascore.component;
+
+import com.jpmc.midascore.foundation.Transaction;
+import com.jpmc.midascore.service.TransactionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TransactionListener {
+    private static final Logger log = LoggerFactory.getLogger(TransactionListener.class);
+
+    private final TransactionService transactionService;
+
+    public TransactionListener(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    @KafkaListener(
+        topics = "${general.kafka-topic}",
+        groupId = "midas-core-group",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(Transaction tx) {
+        log.info("Received Transaction: {}", tx);
+        transactionService.process(tx);
+    }
+}

--- a/src/main/java/com/jpmc/midascore/config/KafkaConfig.java
+++ b/src/main/java/com/jpmc/midascore/config/KafkaConfig.java
@@ -1,0 +1,72 @@
+package com.jpmc.midascore.config;
+
+import com.jpmc.midascore.foundation.Transaction;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    // ---------- Producer ----------
+
+    @Bean
+    public ProducerFactory<String, Transaction> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        // Avoid type headers to keep tests simple
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Transaction> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    // ---------- Consumer ----------
+
+    @Bean
+    public ConsumerFactory<String, Transaction> consumerFactory() {
+        JsonDeserializer<Transaction> valueDeserializer = new JsonDeserializer<>(Transaction.class);
+        valueDeserializer.addTrustedPackages("*");
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "midas-core-group");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer);
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), valueDeserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Transaction> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Transaction> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/jpmc/midascore/config/RestConfig.java
+++ b/src/main/java/com/jpmc/midascore/config/RestConfig.java
@@ -1,0 +1,18 @@
+package com.jpmc.midascore.config;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder b) {
+        return b
+            .setConnectTimeout(Duration.ofSeconds(2))
+            .setReadTimeout(Duration.ofSeconds(2))
+            .build();
+    }
+}

--- a/src/main/java/com/jpmc/midascore/controller/BalanceController.java
+++ b/src/main/java/com/jpmc/midascore/controller/BalanceController.java
@@ -1,0 +1,30 @@
+package com.jpmc.midascore.controller;
+
+import com.jpmc.midascore.foundation.Balance;
+import com.jpmc.midascore.entity.UserRecord;
+import com.jpmc.midascore.repository.UserRepository;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class BalanceController {
+
+    private final UserRepository userRepository;
+
+    public BalanceController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    // GET /balance?userId=123
+    @GetMapping(value = "/balance", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Balance getBalance(@RequestParam("userId") long userId) {
+        if (userId <= 0) {
+            return new Balance(0f);
+        }
+        UserRecord user = userRepository.findById(userId); // returns entity directly in your repo
+        if (user == null) {
+            return new Balance(0f);
+        }
+        return new Balance(user.getBalance());
+    }
+}

--- a/src/main/java/com/jpmc/midascore/entity/TransactionRecord.java
+++ b/src/main/java/com/jpmc/midascore/entity/TransactionRecord.java
@@ -1,0 +1,41 @@
+package com.jpmc.midascore.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class TransactionRecord {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private UserRecord sender;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_id")
+    private UserRecord recipient;
+
+    @Column(nullable = false)
+    private float amount;
+
+    public TransactionRecord() {}
+
+    public TransactionRecord(UserRecord sender, UserRecord recipient, float amount) {
+        this.sender = sender;
+        this.recipient = recipient;
+        this.amount = amount;
+    }
+
+    @Column(nullable = false)
+    private float incentive = 0f;
+
+    public float getIncentive() { return incentive; }
+    public void setIncentive(float incentive) { this.incentive = incentive; }
+
+    public Long getId() { return id; }
+    public UserRecord getSender() { return sender; }
+    public UserRecord getRecipient() { return recipient; }
+    public float getAmount() { return amount; }
+}

--- a/src/main/java/com/jpmc/midascore/foundation/Incentive.java
+++ b/src/main/java/com/jpmc/midascore/foundation/Incentive.java
@@ -1,0 +1,11 @@
+package com.jpmc.midascore.foundation;
+
+public class Incentive {
+    private float amount;
+
+    public Incentive() {}
+    public Incentive(float amount) { this.amount = amount; }
+
+    public float getAmount() { return amount; }
+    public void setAmount(float amount) { this.amount = amount; }
+}

--- a/src/main/java/com/jpmc/midascore/repository/TransactionRepository.java
+++ b/src/main/java/com/jpmc/midascore/repository/TransactionRepository.java
@@ -1,0 +1,7 @@
+package com.jpmc.midascore.repository;
+
+import com.jpmc.midascore.entity.TransactionRecord;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TransactionRepository extends CrudRepository<TransactionRecord, Long> {
+}

--- a/src/main/java/com/jpmc/midascore/service/TransactionService.java
+++ b/src/main/java/com/jpmc/midascore/service/TransactionService.java
@@ -1,0 +1,80 @@
+package com.jpmc.midascore.service;
+
+import com.jpmc.midascore.entity.TransactionRecord;
+import com.jpmc.midascore.entity.UserRecord;
+import com.jpmc.midascore.foundation.Incentive;
+import com.jpmc.midascore.foundation.Transaction;
+import com.jpmc.midascore.repository.TransactionRepository;
+import com.jpmc.midascore.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class TransactionService {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionService.class);
+
+    private final UserRepository userRepository;
+    private final TransactionRepository transactionRepository;
+    private final RestTemplate restTemplate;
+
+    // Default to localhost:8080/incentive so it "just works" if the property is missing.
+    @Value("${incentive.api-url:http://localhost:8080/incentive}")
+    private String incentiveUrl;
+
+    public TransactionService(UserRepository userRepository,
+                              TransactionRepository transactionRepository,
+                              RestTemplate restTemplate) {
+        this.userRepository = userRepository;
+        this.transactionRepository = transactionRepository;
+        this.restTemplate = restTemplate;
+    }
+
+    @Transactional
+    public void process(Transaction tx) {
+        // 1) Validate users
+        UserRecord sender = userRepository.findById(tx.getSenderId());
+        UserRecord recipient = userRepository.findById(tx.getRecipientId());
+        if (sender == null || recipient == null) {
+            log.debug("Discarding tx: invalid sender/recipient (senderId={}, recipientId={})",
+                    tx.getSenderId(), tx.getRecipientId());
+            return;
+        }
+
+        // 2) Validate funds
+        if (sender.getBalance() < tx.getAmount()) {
+            log.debug("Discarding tx: insufficient funds (senderId={}, bal={}, amt={})",
+                    sender.getId(), sender.getBalance(), tx.getAmount());
+            return;
+        }
+
+        // 3) Call Incentive API (safe to treat failures as 0 incentive)
+        float incentiveAmt = 0f;
+        try {
+            Incentive inc = restTemplate.postForObject(incentiveUrl, tx, Incentive.class);
+            if (inc != null && inc.getAmount() >= 0f) {
+                incentiveAmt = inc.getAmount();
+            }
+            log.debug("Incentive API returned {}", incentiveAmt);
+        } catch (Exception e) {
+            log.warn("Incentive API call failed; continuing with 0 incentive. Reason: {}", e.toString());
+        }
+
+        // 4) Apply balances
+        //    - Sender pays ONLY the transaction amount
+        //    - Recipient receives amount + incentive
+        sender.setBalance(sender.getBalance() - tx.getAmount());
+        recipient.setBalance(recipient.getBalance() + tx.getAmount() + incentiveAmt);
+        userRepository.save(sender);
+        userRepository.save(recipient);
+
+        // 5) Persist a record including the incentive
+        TransactionRecord record = new TransactionRecord(sender, recipient, tx.getAmount());
+        record.setIncentive(incentiveAmt);
+        transactionRepository.save(record);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+general:
+  kafka-topic: test-topic
+
+incentive:
+  api-url: http://localhost:8080/incentive
+
+server:
+  port: 33400

--- a/src/test/java/com/jpmc/midascore/KafkaProducer.java
+++ b/src/test/java/com/jpmc/midascore/KafkaProducer.java
@@ -7,16 +7,23 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class KafkaProducer {
+
     private final String topic;
     private final KafkaTemplate<String, Transaction> kafkaTemplate;
 
-    public KafkaProducer(@Value("${general.kafka-topic}") String topic, KafkaTemplate<String, Transaction> kafkaTemplate) {
+    public KafkaProducer(@Value("${general.kafka-topic}") String topic,
+                         KafkaTemplate<String, Transaction> kafkaTemplate) {
         this.topic = topic;
         this.kafkaTemplate = kafkaTemplate;
     }
 
+    /** The tests call this with a CSV line: "fromUserId, toUserId, amount" */
     public void send(String transactionLine) {
-        String[] transactionData = transactionLine.split(", ");
-        kafkaTemplate.send(topic, new Transaction(Long.parseLong(transactionData[0]), Long.parseLong(transactionData[1]), Float.parseFloat(transactionData[2])));
+        String[] parts = transactionLine.split(",\\s*");
+        long from = Long.parseLong(parts[0]);
+        long to = Long.parseLong(parts[1]);
+        float amount = Float.parseFloat(parts[2]);
+
+        kafkaTemplate.send(topic, new Transaction(from, to, amount));
     }
 }

--- a/src/test/java/com/jpmc/midascore/TaskTwoTests.java
+++ b/src/test/java/com/jpmc/midascore/TaskTwoTests.java
@@ -8,11 +8,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "general.kafka-topic=test-topic"
+})
+@EmbeddedKafka(partitions = 1, topics = { "test-topic" })
 @DirtiesContext
-@EmbeddedKafka(partitions = 1, brokerProperties = {"listeners=PLAINTEXT://localhost:9092", "port=9092"})
 class TaskTwoTests {
-    static final Logger logger = LoggerFactory.getLogger(TaskTwoTests.class);
+
+    private static final Logger logger = LoggerFactory.getLogger(TaskTwoTests.class);
 
     @Autowired
     private KafkaProducer kafkaProducer;
@@ -28,14 +32,10 @@ class TaskTwoTests {
         }
         Thread.sleep(2000);
         logger.info("----------------------------------------------------------");
-        logger.info("----------------------------------------------------------");
-        logger.info("----------------------------------------------------------");
         logger.info("use your debugger to watch for incoming transactions");
-        logger.info("kill this test once you find the answer");
         while (true) {
             Thread.sleep(20000);
             logger.info("...");
         }
     }
-
 }


### PR DESCRIPTION
Implements Tasks 2–5 of the Forage J.P. Morgan SE simulation by building out Midas Core—a Spring Boot service that ingests, validates, persists, and enriches transactions, and exposes balances via a small read API.

Task 2 – Kafka Integration

- Added a Spring Kafka listener to consume Transaction messages from the configured topic.
- Introduced Kafka configuration (consumer/producer factories, JSON (de)serializers, and a ConcurrentKafkaListenerContainerFactory) so the listener receives Transaction objects directly.
- Verified with Embedded Kafka (TaskTwoTests) and used breakpoints to capture the first four transaction amounts.

Task 3 – H2/JPA Persistence

- Validated senderId/recipientId and sufficient funds.
- Applied balance updates atomically in a single DB transaction.
- Persisted each accepted transaction as a TransactionRecord with many-to-one links to UserRecord (sender/recipient).

Task 4 – Incentive REST API

- Posted validated Transaction to the external Incentive API; parsed Incentive { amount }.
- Credited recipients with amount + incentive while senders pay amount only.
- Stored incentive on each TransactionRecord.

Task 5 – Read API (/balance)

- Exposed GET /balance?userId=... returning JSON Balance.
- Returns 0 for unknown users.

Changes (by area):

Kafka (Task 2):

- src/main/java/com/jpmc/midascore/config/KafkaConfig.java
Consumer/producer factories, JSON (de)serializers, and ConcurrentKafkaListenerContainerFactory (topic from application.yml).

- src/main/java/com/jpmc/midascore/component/TransactionListener.java
@KafkaListener that receives Transaction and delegates to the service layer (used for TaskTwoTests debugging).

Domain & Persistence (Task 3):

- src/main/java/com/jpmc/midascore/service/TransactionService.java
Validation → balance updates → persistence (later extended for Task 4).

- src/main/java/com/jpmc/midascore/entity/TransactionRecord.java
JPA entity: sender, recipient (many-to-one), amount, incentive.

- src/main/java/com/jpmc/midascore/repository/TransactionRepository.java
Repository for TransactionRecord.

External REST (Task 4):

- src/main/java/com/jpmc/midascore/config/RestConfig.java
RestTemplate bean (short timeouts).

- src/main/java/com/jpmc/midascore/foundation/Incentive.java
DTO for Incentive API response.

Read API (Task 5):

- src/main/java/com/jpmc/midascore/controller/BalanceController.java
GET /balance?userId=<long> → returns Balance { amount } JSON.

Config:

- src/main/resources/application.yml
Kafka topic property; incentive API URL; JPA/H2 settings; server port for tests.

(Existing scaffold files such as foundation/Transaction.java, foundation/Balance.java, entity/UserRecord.java, repository/UserRepository.java, and MidasCoreApplication.java remain in place.)

Notes:

- Kafka gives decoupling and burst tolerance; the listener consumes JSON → Transaction via configured deserializers.
- JPA/H2 ensures transactional integrity for balance updates and keeps the DB backend swappable.
- Incentive API failures default to incentive 0 (no extra debit to sender).
- /balance returns 0 for unknown users and preserves Balance.toString() format required by tests.