### PR TITLE
Add dependencies for Spring Boot, Kafka, and testing

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -1,0 +1,16 @@
+general:
+  kafka-topic: transactions
+
+spring:
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: midas-core-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.jpmc.midascore.foundation"
+        spring.json.value.default.type: com.jpmc.midascore.foundation.Transaction

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,50 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+        <!-- Spring Boot Starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.2.5</version>
+        </dependency>
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+            <version>3.1.4</version>
+        </dependency>
+        <!-- H2 in-memory database -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.2.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <version>3.1.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.19.1</version>
+            <scope>test</scope>
+        </dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/test/java/com/jpmc/midascore/KafkaConsumer.java
+++ b/src/test/java/com/jpmc/midascore/KafkaConsumer.java
@@ -1,0 +1,17 @@
+package com.jpmc.midascore;
+
+import com.jpmc.midascore.foundation.Transaction;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import static com.jpmc.midascore.TaskTwoTests.logger;
+
+@Component
+public class KafkaConsumer {
+
+    @KafkaListener(topics = "${general.kafka-topic}", groupId = "midas-core-group")
+    public void listen(Transaction transaction) {
+        System.out.println("✅ Received transaction: " + transaction);
+    }
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+general.kafka-topic=test-topic


### PR DESCRIPTION
Added Spring Boot starters for JPA and Web, Kafka dependencies, H2 in-memory database, and testing libraries to pom.xml. Also added test application.properties with Kafka topic configuration.