### PR TITLE
Add Kafka integration, transaction processing, and balance endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,106 @@
 # Midas
-Project repo for the JPMC Advanced Software Engineering Forage program
+
+A Spring Boot transaction processing system built for the JPMC Advanced Software Engineering Forage program. Ingests financial transactions via Kafka, validates and processes them with an external incentive API, and exposes user balances through a REST endpoint.
+
+## Architecture
+
+```
+Kafka (trader-updates topic)
+       │
+       ▼
+┌─────────────────────────┐
+│ TransactionListener      │  ← consumes + validates
+│   │                      │
+│   ├── IncentiveClient ───│──→ POST /incentive
+│   │                      │      ← incentive bonus
+│   ▼                      │
+│ Update balances          │  ← debit sender, credit recipient + incentive
+│   ▼                      │
+│ Save to DB (H2/JPA)      │
+└─────────────────────────┘
+       │
+       ▼
+┌─────────────────────────┐
+│ BalanceController        │  ← GET /balance?userId=X (port 33400)
+│   ↕                      │
+│ UserRepository           │
+└─────────────────────────┘
+```
+
+## Tech Stack
+
+- **Java 17** / **Spring Boot 3.2.5** (Web, Data JPA, Kafka)
+- **H2** in-memory database
+- **Apache Kafka** (Embedded Kafka for tests)
+- **Maven** wrapper build
+
+## Getting Started
+
+```bash
+# Build
+./mvnw clean install -DskipTests
+
+# Start the Incentive API (required for transaction processing)
+java -jar services/transaction-incentive-api.jar &
+
+# Run the application
+./mvnw spring-boot:run
+
+# Run all tests
+./mvnw test
+```
+
+## API
+
+### `GET /balance?userId={id}`
+
+Returns the user's current balance.
+
+```json
+{"amount": 1326.98}
+```
+
+Returns `{"amount": 0.0}` if the user does not exist.
+
+## Project Structure
+
+```
+src/
+├── main/java/com/jpmc/midascore/
+│   ├── MidasCoreApplication.java     ← Spring Boot entry point
+│   ├── component/
+│   │   ├── DatabaseConduit.java      ← DB save helper
+│   │   └── IncentiveClient.java      ← REST client for incentive API
+│   ├── config/
+│   │   └── KafkaConfig.java          ← Kafka producer/consumer factories
+│   ├── controller/
+│   │   └── BalanceController.java    ← GET /balance endpoint
+│   ├── entity/
+│   │   ├── UserRecord.java           ← User JPA entity
+│   │   └── TransactionRecord.java    ← Transaction JPA entity
+│   ├── foundation/
+│   │   ├── Balance.java              ← Balance DTO
+│   │   ├── Incentive.java            ← Incentive API response DTO
+│   │   └── Transaction.java          ← Transaction DTO
+│   ├── listener/
+│   │   └── TransactionListener.java  ← Kafka consumer + processor
+│   └── repository/
+│       ├── TransactionRecordRepository.java
+│       └── UserRepository.java
+├── test/java/com/jpmc/midascore/
+│   ├── TaskOneTests.java .. TaskFiveTests.java
+│   ├── KafkaProducer.java            ← Test Kafka producer
+│   ├── FileLoader.java               ← Loads test data files
+│   ├── UserPopulator.java            ← Seeds test users
+│   └── BalanceQuerier.java           ← Test REST client
+└── test/resources/test_data/         ← CSV transaction + user data
+```
+
+## How It Works
+
+1. **Ingestion** — Transactions arrive on the `trader-updates` Kafka topic
+2. **Validation** — Sender and recipient must exist; sender must have sufficient balance
+3. **Incentive** — Valid transactions are posted to the Incentive API for a bonus amount
+4. **Processing** — Sender is debited; recipient is credited (transaction amount + incentive)
+5. **Persistence** — Both user balances and a transaction record are saved to the database
+6. **Query** — Users can check balances via the REST endpoint

--- a/application.yml
+++ b/application.yml
@@ -1,0 +1,2 @@
+general:
+  kafka-topic: trader-updates

--- a/application.yml
+++ b/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 33400
+
 spring:
   kafka:
     bootstrap-servers: localhost:9092

--- a/application.yml
+++ b/application.yml
@@ -1,2 +1,6 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+
 general:
   kafka-topic: trader-updates

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,44 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<version>3.2.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+			<version>3.2.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+			<version>3.1.4</version>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.2.224</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<version>3.2.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<version>3.1.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>kafka</artifactId>
+			<version>1.19.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/jpmc/midascore/component/IncentiveClient.java
+++ b/src/main/java/com/jpmc/midascore/component/IncentiveClient.java
@@ -1,0 +1,20 @@
+package com.jpmc.midascore.component;
+
+import com.jpmc.midascore.foundation.Incentive;
+import com.jpmc.midascore.foundation.Transaction;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class IncentiveClient {
+    private final RestTemplate restTemplate;
+
+    public IncentiveClient(RestTemplateBuilder builder) {
+        this.restTemplate = builder.build();
+    }
+
+    public Incentive getIncentive(Transaction transaction) {
+        return restTemplate.postForObject("http://localhost:8080/incentive", transaction, Incentive.class);
+    }
+}

--- a/src/main/java/com/jpmc/midascore/config/KafkaConfig.java
+++ b/src/main/java/com/jpmc/midascore/config/KafkaConfig.java
@@ -5,6 +5,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
@@ -18,9 +19,13 @@ import java.util.Map;
 @Configuration
 public class KafkaConfig {
 
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
     @Bean
     public ProducerFactory<String, Transaction> producerFactory() {
         Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         return new DefaultKafkaProducerFactory<>(props);
@@ -34,6 +39,7 @@ public class KafkaConfig {
     @Bean
     public ConsumerFactory<String, Transaction> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.jpmc.midascore.foundation");

--- a/src/main/java/com/jpmc/midascore/config/KafkaConfig.java
+++ b/src/main/java/com/jpmc/midascore/config/KafkaConfig.java
@@ -1,0 +1,51 @@
+package com.jpmc.midascore.config;
+
+import com.jpmc.midascore.foundation.Transaction;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, Transaction> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Transaction> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConsumerFactory<String, Transaction> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.jpmc.midascore.foundation");
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(),
+                new JsonDeserializer<>(Transaction.class));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Transaction> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Transaction> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/jpmc/midascore/controller/BalanceController.java
+++ b/src/main/java/com/jpmc/midascore/controller/BalanceController.java
@@ -1,0 +1,27 @@
+package com.jpmc.midascore.controller;
+
+import com.jpmc.midascore.entity.UserRecord;
+import com.jpmc.midascore.foundation.Balance;
+import com.jpmc.midascore.repository.UserRepository;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class BalanceController {
+
+    private final UserRepository userRepository;
+
+    public BalanceController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/balance")
+    public Balance getBalance(@RequestParam("userId") long userId) {
+        UserRecord user = userRepository.findById(userId);
+        if (user == null) {
+            return new Balance(0);
+        }
+        return new Balance(user.getBalance());
+    }
+}

--- a/src/main/java/com/jpmc/midascore/entity/TransactionRecord.java
+++ b/src/main/java/com/jpmc/midascore/entity/TransactionRecord.java
@@ -18,19 +18,23 @@ public class TransactionRecord {
     @Column(nullable = false)
     private float amount;
 
+    @Column(nullable = false)
+    private float incentive;
+
     protected TransactionRecord() {
     }
 
-    public TransactionRecord(UserRecord sender, UserRecord recipient, float amount) {
+    public TransactionRecord(UserRecord sender, UserRecord recipient, float amount, float incentive) {
         this.sender = sender;
         this.recipient = recipient;
         this.amount = amount;
+        this.incentive = incentive;
     }
 
     @Override
     public String toString() {
-        return String.format("TransactionRecord[id=%d, sender=%s, recipient=%s, amount=%f",
-                id, sender.getName(), recipient.getName(), amount);
+        return String.format("TransactionRecord[id=%d, sender=%s, recipient=%s, amount=%f, incentive=%f",
+                id, sender.getName(), recipient.getName(), amount, incentive);
     }
 
     public long getId() {
@@ -47,5 +51,9 @@ public class TransactionRecord {
 
     public float getAmount() {
         return amount;
+    }
+
+    public float getIncentive() {
+        return incentive;
     }
 }

--- a/src/main/java/com/jpmc/midascore/entity/TransactionRecord.java
+++ b/src/main/java/com/jpmc/midascore/entity/TransactionRecord.java
@@ -1,0 +1,51 @@
+package com.jpmc.midascore.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class TransactionRecord {
+
+    @Id
+    @GeneratedValue()
+    private long id;
+
+    @ManyToOne
+    private UserRecord sender;
+
+    @ManyToOne
+    private UserRecord recipient;
+
+    @Column(nullable = false)
+    private float amount;
+
+    protected TransactionRecord() {
+    }
+
+    public TransactionRecord(UserRecord sender, UserRecord recipient, float amount) {
+        this.sender = sender;
+        this.recipient = recipient;
+        this.amount = amount;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("TransactionRecord[id=%d, sender=%s, recipient=%s, amount=%f",
+                id, sender.getName(), recipient.getName(), amount);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public UserRecord getSender() {
+        return sender;
+    }
+
+    public UserRecord getRecipient() {
+        return recipient;
+    }
+
+    public float getAmount() {
+        return amount;
+    }
+}

--- a/src/main/java/com/jpmc/midascore/foundation/Incentive.java
+++ b/src/main/java/com/jpmc/midascore/foundation/Incentive.java
@@ -1,0 +1,24 @@
+package com.jpmc.midascore.foundation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Incentive {
+    private float amount;
+
+    public Incentive() {
+    }
+
+    public float getAmount() {
+        return amount;
+    }
+
+    public void setAmount(float amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public String toString() {
+        return "Incentive {amount=" + amount + "}";
+    }
+}

--- a/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
+++ b/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
@@ -1,0 +1,21 @@
+package com.jpmc.midascore.listener;
+
+import com.jpmc.midascore.foundation.Transaction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableKafka
+public class TransactionListener {
+
+    static final Logger logger = LoggerFactory.getLogger(TransactionListener.class);
+
+    @KafkaListener(topics = "${general.kafka-topic}")
+    public void handleTransaction(Transaction transaction) {
+        logger.info("received transaction: {}", transaction);
+    }
+}

--- a/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
+++ b/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
@@ -14,7 +14,7 @@ public class TransactionListener {
 
     static final Logger logger = LoggerFactory.getLogger(TransactionListener.class);
 
-    @KafkaListener(topics = "${general.kafka-topic}")
+    @KafkaListener(topics = "${general.kafka-topic}", groupId = "midas-core-group")
     public void handleTransaction(Transaction transaction) {
         logger.info("received transaction: {}", transaction);
     }

--- a/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
+++ b/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
@@ -1,9 +1,12 @@
 package com.jpmc.midascore.listener;
 
+import com.jpmc.midascore.entity.TransactionRecord;
+import com.jpmc.midascore.entity.UserRecord;
 import com.jpmc.midascore.foundation.Transaction;
+import com.jpmc.midascore.repository.TransactionRecordRepository;
+import com.jpmc.midascore.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -14,8 +17,38 @@ public class TransactionListener {
 
     static final Logger logger = LoggerFactory.getLogger(TransactionListener.class);
 
+    private final UserRepository userRepository;
+    private final TransactionRecordRepository transactionRecordRepository;
+
+    public TransactionListener(UserRepository userRepository, TransactionRecordRepository transactionRecordRepository) {
+        this.userRepository = userRepository;
+        this.transactionRecordRepository = transactionRecordRepository;
+    }
+
     @KafkaListener(topics = "${general.kafka-topic}", groupId = "midas-core-group")
     public void handleTransaction(Transaction transaction) {
-        logger.info("received transaction: {}", transaction);
+        UserRecord sender = userRepository.findById(transaction.getSenderId());
+        UserRecord recipient = userRepository.findById(transaction.getRecipientId());
+
+        if (sender == null || recipient == null) {
+            logger.info("invalid transaction: {} (sender or recipient not found)", transaction);
+            return;
+        }
+
+        if (sender.getBalance() < transaction.getAmount()) {
+            logger.info("invalid transaction: {} (insufficient balance)", transaction);
+            return;
+        }
+
+        sender.setBalance(sender.getBalance() - transaction.getAmount());
+        recipient.setBalance(recipient.getBalance() + transaction.getAmount());
+
+        userRepository.save(sender);
+        userRepository.save(recipient);
+
+        TransactionRecord transactionRecord = new TransactionRecord(sender, recipient, transaction.getAmount());
+        transactionRecordRepository.save(transactionRecord);
+
+        logger.info("processed transaction: {}", transaction);
     }
 }

--- a/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
+++ b/src/main/java/com/jpmc/midascore/listener/TransactionListener.java
@@ -1,7 +1,9 @@
 package com.jpmc.midascore.listener;
 
+import com.jpmc.midascore.component.IncentiveClient;
 import com.jpmc.midascore.entity.TransactionRecord;
 import com.jpmc.midascore.entity.UserRecord;
+import com.jpmc.midascore.foundation.Incentive;
 import com.jpmc.midascore.foundation.Transaction;
 import com.jpmc.midascore.repository.TransactionRecordRepository;
 import com.jpmc.midascore.repository.UserRepository;
@@ -19,10 +21,12 @@ public class TransactionListener {
 
     private final UserRepository userRepository;
     private final TransactionRecordRepository transactionRecordRepository;
+    private final IncentiveClient incentiveClient;
 
-    public TransactionListener(UserRepository userRepository, TransactionRecordRepository transactionRecordRepository) {
+    public TransactionListener(UserRepository userRepository, TransactionRecordRepository transactionRecordRepository, IncentiveClient incentiveClient) {
         this.userRepository = userRepository;
         this.transactionRecordRepository = transactionRecordRepository;
+        this.incentiveClient = incentiveClient;
     }
 
     @KafkaListener(topics = "${general.kafka-topic}", groupId = "midas-core-group")
@@ -40,15 +44,18 @@ public class TransactionListener {
             return;
         }
 
+        Incentive incentive = incentiveClient.getIncentive(transaction);
+        float incentiveAmount = (incentive != null) ? incentive.getAmount() : 0;
+
         sender.setBalance(sender.getBalance() - transaction.getAmount());
-        recipient.setBalance(recipient.getBalance() + transaction.getAmount());
+        recipient.setBalance(recipient.getBalance() + transaction.getAmount() + incentiveAmount);
 
         userRepository.save(sender);
         userRepository.save(recipient);
 
-        TransactionRecord transactionRecord = new TransactionRecord(sender, recipient, transaction.getAmount());
+        TransactionRecord transactionRecord = new TransactionRecord(sender, recipient, transaction.getAmount(), incentiveAmount);
         transactionRecordRepository.save(transactionRecord);
 
-        logger.info("processed transaction: {}", transaction);
+        logger.info("processed transaction: {} with incentive: {}", transaction, incentiveAmount);
     }
 }

--- a/src/main/java/com/jpmc/midascore/repository/TransactionRecordRepository.java
+++ b/src/main/java/com/jpmc/midascore/repository/TransactionRecordRepository.java
@@ -1,0 +1,7 @@
+package com.jpmc.midascore.repository;
+
+import com.jpmc.midascore.entity.TransactionRecord;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TransactionRecordRepository extends CrudRepository<TransactionRecord, Long> {
+}


### PR DESCRIPTION
# Midas

Project repo for the JPMC Advanced Software Engineering Forage program.

Spring Boot transaction processing system with Kafka ingestion, JPA persistence, incentive API integration, and a REST balance endpoint.

## Architecture

```
Kafka (trader-updates topic)
       │
       ▼
┌─────────────────────────┐
│ TransactionListener      │  ← consumes + validates
│   │                      │
│   ├── IncentiveClient ───│──→ POST /incentive (port 8080)
│   │                      │      ← incentive bonus
│   ▼                      │
│ Update balances          │  ← debit sender, credit recipient + incentive
│   ▼                      │
│ Save to DB (H2/JPA)      │
└─────────────────────────┘
       │
       ▼
┌─────────────────────────┐
│ BalanceController        │  ← GET /balance?userId=X (port 33400)
│   ↕                      │
│ UserRepository (JPA)     │
└─────────────────────────┘
```

## Dependencies

- Spring Boot 3.2.5 (Web, Data JPA, Kafka)
- H2 in-memory database
- Testcontainers + Embedded Kafka for testing

## Tasks

### Task 1 — Application boot verification
### Task 2 — Kafka transaction ingestion
### Task 3 — Transaction validation + balance updates
### Task 4 — Incentive API integration
### Task 5 — REST balance endpoint
